### PR TITLE
Revert to url.parse

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,14 @@
 module.exports = {
-  "extends": "airbnb-base",
-  "env": {
-    "browser": true,
-    "node": true,
-    "jest": true,
+  extends: 'airbnb-base',
+  env: {
+    browser: true,
+    node: true,
+    jest: true,
   },
-  "rules": {
-    "import/prefer-default-export": "off",
-    "array-callback-return": "off",
-    "linebreak-style": "off",
-    "no-console": 1
-  }
+  rules: {
+    'import/prefer-default-export': 'off',
+    'array-callback-return': 'off',
+    'linebreak-style': 'off',
+    'no-console': 1,
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "buying-catalogue-library",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buying-catalogue-library",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A library for buying-catalogue front end apps",
   "main": "lib/index.js",
   "scripts": {

--- a/src/apiProvider/index.js
+++ b/src/apiProvider/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const getHeaders = accessToken => (accessToken ? { headers: { Authorization: `Bearer ${accessToken}` } } : {});
+const getHeaders = (accessToken) => (accessToken ? { headers: { Authorization: `Bearer ${accessToken}` } } : {});
 
 export const deleteData = async ({
   endpoint,
@@ -81,7 +81,6 @@ export const patchData = async ({
     throw err;
   }
 };
-
 
 export const getDocument = async ({
   endpoint, logger,

--- a/src/helpers/contextCreatorHelpers/index.js
+++ b/src/helpers/contextCreatorHelpers/index.js
@@ -15,7 +15,7 @@ export const addErrorsAndDataToManifest = ({ manifest, errors, data }) => ({
   }),
 });
 
-export const formatAllErrors = questionsWithErrors => questionsWithErrors.reduce(
+export const formatAllErrors = (questionsWithErrors) => questionsWithErrors.reduce(
   (acc, question) => {
     if (question.error) {
       question.error.message.split(', ').forEach((errorString) => {

--- a/src/middleware/authProvider/index.js
+++ b/src/middleware/authProvider/index.js
@@ -1,3 +1,4 @@
+import url from 'url';
 import passport from 'passport';
 import { Strategy, Issuer } from 'openid-client';
 import session from 'express-session';
@@ -77,7 +78,7 @@ export class AuthProvider {
   login() {
     return (req, res, next) => {
       const options = {
-        state: new URL(req.headers.referer).pathname,
+        state: url.parse(req.headers.referer).pathname,
       };
       this.passport.authenticate('oidc', options)(req, res, next);
     };

--- a/src/middleware/authenticationRoutes/index.js
+++ b/src/middleware/authenticationRoutes/index.js
@@ -27,8 +27,8 @@ export const authenticationRoutes = ({
 
     if (req.headers.cookie) {
       req.headers.cookie.split(';')
-        .map(cookie => cookie.split('=')[0])
-        .forEach(cookieKey => res.clearCookie(cookieKey));
+        .map((cookie) => cookie.split('=')[0])
+        .forEach((cookieKey) => res.clearCookie(cookieKey));
     }
 
     res.redirect(logoutRedirectPath);


### PR DESCRIPTION
Revert to deprecated `url.parse` as `url.parse` will handle relative URLs whereas the new URL API requires a base URL. See node [issue 12682](https://github.com/nodejs/node/issues/12682).

Activity: [AB#11185](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/11185)
Task: [AB#11198](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/11198)